### PR TITLE
Refactor/api structure

### DIFF
--- a/src/api/sh4reCustomAxios.ts
+++ b/src/api/sh4reCustomAxios.ts
@@ -2,7 +2,8 @@ import { ACCESS_TOKEN_KEY } from "@/constants/token.constants";
 import token from "@/libs/token/token";
 import axios, { AxiosInstance } from "axios";
 
-const SERVER_URL = import.meta.env.VITE_SERVER_URL;
+const SERVER_URL = `${import.meta.env.VITE_SERVER_URL}/api/v1`;
+// 모든 엔드포인트 /api/v1로 시작해 통일적으로 사용
 
 const sh4reCustomAxios: AxiosInstance = axios.create({
   baseURL: SERVER_URL,
@@ -32,11 +33,11 @@ sh4reCustomAxios.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const res = await axios.post(`${SERVER_URL}/api/auth/refresh`, null, {
+        const res = await axios.post(`${SERVER_URL}/auth/refresh`, null, {
           withCredentials: true,
         });
 
-        const { accessToken } = res.data.data;
+        const { accessToken } = res.data;
         token.setToken(ACCESS_TOKEN_KEY, accessToken);
 
         originalRequest.headers = {

--- a/src/components/common/layout/Sidebar/index.tsx
+++ b/src/components/common/layout/Sidebar/index.tsx
@@ -47,7 +47,7 @@ const Sidebar = () => {
 
   const handleLogout = async () => {
     try {
-      await sh4reCustomAxios.post("/api/auth/logout");
+      await sh4reCustomAxios.post("/auth/logout");
       token.removeToken();
       navigate("/login");
     } catch (error) {

--- a/src/components/common/layout/sidebar/index.tsx
+++ b/src/components/common/layout/sidebar/index.tsx
@@ -47,7 +47,7 @@ const Sidebar = () => {
 
   const handleLogout = async () => {
     try {
-      await sh4reCustomAxios.post("/api/auth/logout");
+      await sh4reCustomAxios.post("/auth/logout");
       token.removeToken();
       navigate("/login");
     } catch (error) {

--- a/src/hooks/announcements/useAnnouncement.ts
+++ b/src/hooks/announcements/useAnnouncement.ts
@@ -3,18 +3,11 @@ import sh4reCustomAxios from "@/api/sh4reCustomAxios";
 import { Announcement } from "@/types/announcements/announcements";
 import { ANNOUNCEMENTS_QUERY_KEY } from "@/constants/queryKeys";
 
-interface AnnouncementDetailApiResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: Announcement;
-}
-
 const fetchAnnouncementById = async (id: number): Promise<Announcement> => {
-  const res = await sh4reCustomAxios.get<AnnouncementDetailApiResponse>(
+  const res = await sh4reCustomAxios.get<Announcement>(
     `/announcements/${id}`
   );
-  return res.data.data;
+  return res.data;
 };
 
 export const useAnnouncement = (id: number | undefined) => {

--- a/src/hooks/announcements/useAnnouncements.ts
+++ b/src/hooks/announcements/useAnnouncements.ts
@@ -11,7 +11,7 @@ const fetchAnnouncements = async (): Promise<Announcement[]> => {
   const res = await sh4reCustomAxios.get<AnnouncementsApiResponse>(
     "/announcements"
   );
-  return res.data.data.announcements;
+  return res.data.announcements;
 };
 
 export const useAnnouncements = (searchTerm: string) => {

--- a/src/hooks/auth/login/useLogin.ts
+++ b/src/hooks/auth/login/useLogin.ts
@@ -20,13 +20,10 @@ const useLogin = () => {
         toast.info("비밀번호를 입력해주세요.");
         return;
       } else {
-        const { data } = await sh4reCustomAxios.post(
-          "/api/auth/login",
-          userInfo
-        );
+        const { data } = await sh4reCustomAxios.post("/auth/login", userInfo);
 
         if (data) {
-          const accessToken = data.data.accessToken;
+          const accessToken = data.accessToken;
           token.setToken(ACCESS_TOKEN_KEY, accessToken);
           const { data: user } = await refetchUser();
           toast.success(`${user.name}님, 환영합니다!`);

--- a/src/hooks/auth/login/useUser.ts
+++ b/src/hooks/auth/login/useUser.ts
@@ -9,8 +9,8 @@ export const useUser = () => {
   return useQuery({
     queryKey: ["user"],
     queryFn: async () => {
-      const { data } = await sh4reCustomAxios.get("/user/me");
-      return data.data.me;
+      const { data } = await sh4reCustomAxios.get("/users/me");
+      return data.me;
     },
     staleTime: 5 * 60 * 1000,
     enabled: !!accessToken,

--- a/src/hooks/auth/login/useUser.ts
+++ b/src/hooks/auth/login/useUser.ts
@@ -1,6 +1,7 @@
 import sh4reCustomAxios from "@/api/sh4reCustomAxios";
 import { ACCESS_TOKEN_KEY } from "@/constants/token.constants";
 import token from "@/libs/token/token";
+import { UserWithClassInfo } from "@/types/user/user";
 import { useQuery } from "@tanstack/react-query";
 
 export const useUser = () => {
@@ -8,7 +9,7 @@ export const useUser = () => {
 
   return useQuery({
     queryKey: ["user"],
-    queryFn: async () => {
+    queryFn: async (): Promise<UserWithClassInfo> => {
       const { data } = await sh4reCustomAxios.get("/users/me");
       return data.me;
     },

--- a/src/hooks/code/useCode.ts
+++ b/src/hooks/code/useCode.ts
@@ -2,33 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import sh4reCustomAxios from "@/api/sh4reCustomAxios";
 import { CODE } from "@/constants/queryKeys";
 
-export interface CodeDetailType {
-  id: number;
-  title: string;
-  student: string;
-  language: "python" | "sql" | "javascript";
-  description: string;
-  code: string;
-  likeCount: number;
-  isLikedByUser: boolean;
-  className: string;
-  assignment?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface CodeDetailResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: CodeDetailType;
-}
+import type { CodeDetailType } from "@/types/code/code";
 
 const fetchCode = async (codeId: number): Promise<CodeDetailType> => {
-  const res = await sh4reCustomAxios.get<CodeDetailResponse>(
+  const res = await sh4reCustomAxios.get<CodeDetailType>(
     `/codes/${codeId}`
   );
-  return res.data.data;
+  return res.data;
 };
 
 export const useCode = (codeId: number) => {

--- a/src/hooks/code/useCodes.ts
+++ b/src/hooks/code/useCodes.ts
@@ -4,29 +4,12 @@ import { CODE } from "@/constants/queryKeys";
 import type { CodeType } from "@/types/code/code";
 
 interface GetAllCodesResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: CodeType[] | { codes: CodeType[] };
+  codes: CodeType[];
 }
 
 const fetchCodes = async (): Promise<CodeType[]> => {
   const response = await sh4reCustomAxios.get<GetAllCodesResponse>("/codes");
-
-  const data = response.data.data;
-  if (Array.isArray(data)) {
-    return data;
-  } else if (
-    data &&
-    typeof data === "object" &&
-    "codes" in data &&
-    Array.isArray(data.codes)
-  ) {
-    return data.codes;
-  } else {
-    console.error("Unexpected API response structure:", data);
-    return [];
-  }
+  return response.data.codes;
 };
 
 export const useCodes = () => {

--- a/src/hooks/code/useCreateCode.ts
+++ b/src/hooks/code/useCreateCode.ts
@@ -10,15 +10,11 @@ export interface CreateCodeRequest {
   assignment?: string;
   code: string;
   className: string;
+  useAiDescription?: boolean;
 }
 
 interface CreateCodeResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: {
-    codeId: number;
-  };
+  id: number;
 }
 
 const createCode = async (
@@ -32,7 +28,7 @@ const createCode = async (
     delete sanitizedData.description;
   }
 
-  const response = await sh4reCustomAxios.post("/codes", sanitizedData);
+  const response = await sh4reCustomAxios.post<CreateCodeResponse>("/codes", sanitizedData);
   return response.data;
 };
 

--- a/src/hooks/code/useToggleCodeLike.ts
+++ b/src/hooks/code/useToggleCodeLike.ts
@@ -3,17 +3,12 @@ import sh4reCustomAxios from '@/api/sh4reCustomAxios';
 import { CODE } from '@/constants/queryKeys';
 
 interface ToggleLikeResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: {
-    liked: boolean;
-    likes: number;
-  };
+  isLiked: boolean;
+  likeCount: number;
 }
 
 const toggleCodeLike = async (codeId: number): Promise<ToggleLikeResponse> => {
-  const response = await sh4reCustomAxios.post(`/codes/${codeId}/like`);
+  const response = await sh4reCustomAxios.post<ToggleLikeResponse>(`/codes/${codeId}/like`);
   return response.data;
 };
 

--- a/src/hooks/code/useUpdateCode.ts
+++ b/src/hooks/code/useUpdateCode.ts
@@ -1,30 +1,20 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import sh4reCustomAxios from "@/api/sh4reCustomAxios";
 import { CODE } from "@/constants/queryKeys";
-import type { CreateCodeRequest } from "./useCreateCode";
-
-interface UpdateCodeResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: {
-    codeId: number;
-  };
-}
+import type { UpdateCodeReq } from "@/types/code/code";
 
 const updateCode = async (
   codeId: number,
-  data: CreateCodeRequest
-): Promise<UpdateCodeResponse> => {
-  const response = await sh4reCustomAxios.patch(`/codes/${codeId}`, data);
-  return response.data;
+  data: UpdateCodeReq
+): Promise<void> => {
+  await sh4reCustomAxios.patch(`/codes/${codeId}`, data);
 };
 
 export const useUpdateCode = (codeId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: CreateCodeRequest) => updateCode(codeId, data),
+    mutationFn: (data: UpdateCodeReq) => updateCode(codeId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [CODE.LIST] });
       queryClient.invalidateQueries({ queryKey: [CODE.DETAIL, codeId] });

--- a/src/pages/student/Code/Create/index.tsx
+++ b/src/pages/student/Code/Create/index.tsx
@@ -78,7 +78,7 @@ const CodeCreatePage = () => {
 
     try {
       const result = await createCodeMutation.mutateAsync(createData);
-      goToDetail(result.data.codeId);
+      goToDetail(result.id);
     } catch (error) {
       console.error("Failed to create code:", error);
     }

--- a/src/pages/student/Code/Edit/index.tsx
+++ b/src/pages/student/Code/Edit/index.tsx
@@ -8,8 +8,7 @@ import { useCode } from "@/hooks/code/useCode";
 import { useUser } from "@/hooks/auth/login/useUser";
 import { useCodeNavigation } from "@/hooks/code/useCodeNavigation";
 import { chapters } from "@/constants/assignmentData";
-import type { CodeType } from "@/types/code/code";
-import type { CreateCodeRequest } from "@/hooks/code/useCreateCode";
+import type { CodeType, UpdateCodeReq } from "@/types/code/code";
 
 const CodeEditPage = () => {
   const { codeId } = useParams<{ codeId: string }>();
@@ -36,7 +35,7 @@ const CodeEditPage = () => {
     if (existingCode) {
       setCode(existingCode.code);
       setTitle(existingCode.title);
-      setDescription("");
+      setDescription(existingCode.description || "");
       setLanguage(existingCode.language);
       setAssignment(existingCode.assignment || "");
     }
@@ -76,7 +75,7 @@ const CodeEditPage = () => {
 
     const className = `${user.grade}-${user.classNumber}`;
 
-    const updateData: CreateCodeRequest = {
+    const updateData: UpdateCodeReq = {
       title: title.trim(),
       code: code.trim(),
       language,

--- a/src/pages/student/code/create/index.tsx
+++ b/src/pages/student/code/create/index.tsx
@@ -78,7 +78,7 @@ const CodeCreatePage = () => {
 
     try {
       const result = await createCodeMutation.mutateAsync(createData);
-      goToDetail(result.data.codeId);
+      goToDetail(result.id);
     } catch (error) {
       console.error("Failed to create code:", error);
     }

--- a/src/pages/student/code/edit/index.tsx
+++ b/src/pages/student/code/edit/index.tsx
@@ -8,8 +8,7 @@ import { useCode } from "@/hooks/code/useCode";
 import { useUser } from "@/hooks/auth/login/useUser";
 import { useCodeNavigation } from "@/hooks/code/useCodeNavigation";
 import { chapters } from "@/constants/assignmentData";
-import type { CodeType } from "@/types/code/code";
-import type { CreateCodeRequest } from "@/hooks/code/useCreateCode";
+import type { CodeType, UpdateCodeReq } from "@/types/code/code";
 
 const CodeEditPage = () => {
   const { codeId } = useParams<{ codeId: string }>();
@@ -36,7 +35,7 @@ const CodeEditPage = () => {
     if (existingCode) {
       setCode(existingCode.code);
       setTitle(existingCode.title);
-      setDescription("");
+      setDescription(existingCode.description || "");
       setLanguage(existingCode.language);
       setAssignment(existingCode.assignment || "");
     }
@@ -76,7 +75,7 @@ const CodeEditPage = () => {
 
     const className = `${user.grade}-${user.classNumber}`;
 
-    const updateData: CreateCodeRequest = {
+    const updateData: UpdateCodeReq = {
       title: title.trim(),
       code: code.trim(),
       language,

--- a/src/styles/theme/themeContext.tsx
+++ b/src/styles/theme/themeContext.tsx
@@ -18,7 +18,7 @@ export const ThemeProviderCustom = ({ children }: { children: ReactNode }) => {
     const accessToken = localStorage.getItem("accessToken");
     if (accessToken) {
       sh4reCustomAxios
-        .post("/user/theme", {
+        .post("/users/theme", {
           themeName: theme,
         })
         .catch(() => {

--- a/src/types/announcements/announcements.ts
+++ b/src/types/announcements/announcements.ts
@@ -1,23 +1,16 @@
+// response용
 export interface Announcement {
   id: number;
   label: "과제" | "공지";
   title: string;
   author: string;
-  content?: string;
-  schoolYear?: number;
-  grade?: number;
-  classNumber?: number;
-  userId?: number;
-  createdAt?: string;
+  content: string;
+  createdAt: string;
 }
 
+
 export interface AnnouncementsApiResponse {
-  ok: boolean;
-  code: string;
-  message: string;
-  data: {
-    announcements: Announcement[];
-  };
+  announcements: Announcement[];
 }
 
 export interface AnnouncementsLabelProps {

--- a/src/types/code/code.ts
+++ b/src/types/code/code.ts
@@ -1,15 +1,39 @@
 export interface CodeType {
   id: number;
-  class?: string;
+  title: string;
+  student: string;
+  language: "python" | "sql" | "javascript";
+  code: string;
+  likeCount: number;
   className: string;
   assignment?: string;
+  createdAt: string;
+  updatedAt: string;
+  description?: string;
+  likes?: number;
+}
+
+export interface CodeDetailType {
+  id: number;
   title: string;
   student: string;
   language: "python" | "sql" | "javascript";
   description?: string;
   code: string;
-  likes: number;
   likeCount: number;
+  isLikedByUser: boolean;
+  className: string;
+  assignment?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+
+export interface UpdateCodeReq {
+  title: string;
+  language: "python" | "sql" | "javascript";
+  description?: string;
+  code: string;
+  className: string;
+  assignment?: string;
 }

--- a/src/types/code/code.ts
+++ b/src/types/code/code.ts
@@ -10,7 +10,6 @@ export interface CodeType {
   createdAt: string;
   updatedAt: string;
   description?: string;
-  likes?: number;
 }
 
 export interface CodeDetailType {
@@ -27,7 +26,6 @@ export interface CodeDetailType {
   createdAt: string;
   updatedAt: string;
 }
-
 
 export interface UpdateCodeReq {
   title: string;

--- a/src/types/user/user.ts
+++ b/src/types/user/user.ts
@@ -1,0 +1,19 @@
+// /users/me response용
+export interface UserWithClassInfo {
+  id: number;
+  username: string;
+  email: string;
+  name: string;
+  admissionYear: number;
+  role: "STUDENT" | "TEACHER" | "ADMIN";
+  theme: "DARK" | "LIGHT";
+  grade: number;
+  classNumber: number;
+  studentNumber: number;
+  school: {
+    id: number;
+    name: string;
+    code: string;
+  };
+}
+


### PR DESCRIPTION
서버 측 response 규격 변경, url 구조 등 기본적인 아키텍쳐를 리팩터링이 있었습니다.
이에 따라 웹에서도 형식에 맞게 엔드포인트, response 형식을 변경하였습니다.

모든 엔드포인트가 /api/v1으로 시작하기에 customAxios 인스턴스를 생성할 때 서버 주소에 /api/v1을 추가해
반복적인 코드 생성을 방지하였습니다.

또한 사용하지 않는 type도 삭제하였습니다.